### PR TITLE
Jenkins: Add Windows, macOS, and Debian pipelines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
                 sh 'docker login --username "${CRED_USR}" --password "${CRED_PSW}"'
             }
         }
-        stage('build') {
+        stage('build-push-docker') {
             steps {
                 sh '''\
                     docker build \
@@ -25,12 +25,16 @@ pipeline {
                       --label base_image="${base_image}" \
                       --tag="${image_name}" \
                       .
+                    docker push "${image_name}"
                 '''.stripIndent()
             }
         }
-        stage('push') {
+        stage('build-push-debian') {
             steps {
-                sh 'docker push "${image_name}"'
+                sh '''\
+                    BUILD_IMAGE="${build_image}" ./build-deb.sh
+                    aws s3 cp ./concordium-rosetta*.deb s3://distribution.concordium.software/tools/linux/
+                '''.stripIndent()
             }
         }
     }

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 # -- PARAMETERS -- #
 
 # Base image to use for building the binary.
-build_base_image=rust:1.53-slim-buster
+build_base_image="${BUILD_IMAGE}"
 # Directory to use for temporary files.
 build_dir=./tmp/deb
 

--- a/macos.Jenkinsfile
+++ b/macos.Jenkinsfile
@@ -1,11 +1,11 @@
 pipeline {
-    agent { label 'windows' }
+    agent { label 'jenkins-worker' }
     stages {
-        stage('build') {
+        stage('build-push') {
             steps {
                 sh '''\
                     # Set up Rust toolchain.
-                    rustup default 1.53-x86_64-pc-windows-gnu
+                    rustup default 1.53
 
                     # Build binary and run it to get version.
                     version="$(cargo run --release -- --version | awk '{print $2}')"
@@ -13,7 +13,7 @@ pipeline {
                     # Push binary to S3.
                     aws s3 cp \
                         ./target/release/concordium-rosetta.exe \
-                        "s3://distribution.concordium.software/tools/windows/concordium-rosetta_${version}.exe" \
+                        "s3://distribution.concordium.software/tools/macos/concordium-rosetta_${version}.exe" \
                         --grants=read=uri=http://acs.amazonaws.com/groups/global/AllUsers
                 '''.stripIndent()
             }

--- a/macos.Jenkinsfile
+++ b/macos.Jenkinsfile
@@ -5,19 +5,19 @@ pipeline {
             agent { label 'mac' }
             steps {
                 sh '''\
-                    # Set up Rust toolchain.
+                    # Set up Rust toolchain and build binary.
                     rustup default 1.53
-
-                    # Build binary and run it to get version.
-                    version="$(cargo run --release -- --version | awk '{print $2}')"
+                    cargo build --release
                 '''.stripIndent()
                 stash includes: 'target/release/concordium-rosetta', name: 'target'
             }
         }
         stage('push') {
             steps {
-                unstash 'target'
+                unstash 'target' // transfers './target/release/concordium-rosetta'.
                 sh '''\
+                    # Run binary to get version.
+                    version="$(./target/release/concordium-rosetta --version | awk '{print $2}')"
                     # Push binary to S3.
                     aws s3 cp \
                         ./target/release/concordium-rosetta \

--- a/macos.Jenkinsfile
+++ b/macos.Jenkinsfile
@@ -10,12 +10,6 @@ pipeline {
 
                     # Build binary and run it to get version.
                     version="$(cargo run --release -- --version | awk '{print $2}')"
-
-                    # Push binary to S3.
-                    aws s3 cp \
-                        ./target/release/concordium-rosetta.exe \
-                        "s3://distribution.concordium.software/tools/macos/concordium-rosetta_${version}.exe" \
-                        --grants=read=uri=http://acs.amazonaws.com/groups/global/AllUsers
                 '''.stripIndent()
                 stash includes: './target/release/concordium-rosetta', name: 'target'
             }

--- a/macos.Jenkinsfile
+++ b/macos.Jenkinsfile
@@ -12,10 +12,10 @@ pipeline {
                     version="$(cargo run --release -- --version | awk '{print $2}')"
 
                     # Extract binary and append version to name.
-                    mkdir out
+                    mkdir ./out
                     cp ./target/release/concordium-rosetta ./out/concordium-rosetta_${version}
                 '''.stripIndent()
-                stash includes: 'out', name: 'target'
+                stash includes: 'out/', name: 'target'
             }
         }
         stage('push') {

--- a/macos.Jenkinsfile
+++ b/macos.Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
                     # Build binary and run it to get version.
                     version="$(cargo run --release -- --version | awk '{print $2}')"
                 '''.stripIndent()
-                stash includes: './target/release/concordium-rosetta', name: 'target'
+                stash includes: 'target/release/concordium-rosetta', name: 'target'
             }
         }
         stage('push') {

--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -1,0 +1,27 @@
+pipeline {
+    agent { label 'windows' }
+
+    stages {
+        stage('build') {
+            steps {
+                sh '''\
+                    # Set up Rust toolchain.
+                    rustup default 1.53-x86_64-pc-windows-gnu
+
+                    # Build and run binary to get version.
+                    ls
+                    version=$(cargo run --release -- --version | awk '{print $2}')
+                    ls
+                    ls target
+                    ls target/release
+
+                    # Push binary to S3.
+                    aws s3 cp \
+                        ./target/release/concordium-rosetta.exe \
+                        s3://distribution.concordium.software/tools/windows/ \
+                        --grants=read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+                '''.stripIndent()
+            }
+        }
+    }
+}

--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -8,17 +8,13 @@ pipeline {
                     # Set up Rust toolchain.
                     rustup default 1.53-x86_64-pc-windows-gnu
 
-                    # Build and run binary to get version.
-                    ls
-                    version=$(cargo run --release -- --version | awk '{print $2}')
-                    ls
-                    ls target
-                    ls target/release
+                    # Build binary and run it to get version.
+                    version="$(cargo run --release -- --version | awk '{print $2}')"
 
                     # Push binary to S3.
                     aws s3 cp \
                         ./target/release/concordium-rosetta.exe \
-                        s3://distribution.concordium.software/tools/windows/ \
+                        "s3://distribution.concordium.software/tools/windows/concordium-rosetta_${version}.exe" \
                         --grants=read=uri=http://acs.amazonaws.com/groups/global/AllUsers
                 '''.stripIndent()
             }


### PR DESCRIPTION
## Purpose

Publish native binaries for Windows and Debian.

## Changes

Add a pipeline for building a Windows native binary and publish it to S3. Also make the default (Docker) pipeline also extract the binary and put it into a Debian package that is uploaded to S3.