### PR TITLE
Migrate structopt to clap v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 
 env:
   RUST_FMT: nightly-2021-06-09-x86_64-unknown-linux-gnu
-  RUST_CLIPPY: 1.53
+  RUST_CLIPPY: 1.54
 
 jobs:
   fmt:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,15 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,17 +306,32 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -364,7 +370,6 @@ dependencies = [
  "rosetta",
  "serde",
  "serde_json",
- "structopt",
  "thiserror",
  "tokio",
  "tonic",
@@ -1042,6 +1047,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,6 +1590,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "pairing"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1828,7 +1848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.3.3",
  "itertools 0.10.3",
  "log",
  "multimap",
@@ -2356,33 +2376,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -2438,12 +2434,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -2792,12 +2785,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2826,12 +2813,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version = "*"
 
 [dependencies]
 anyhow = "1"
-clap = "2.33"
+clap = { version = "3.1", features = ["derive", "env"] }
 env_logger = "0.9"
 futures = "0.3"
 hex = "0.4"
@@ -23,7 +23,6 @@ log = "0.4"
 prometheus = "0.13.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-structopt = "0.3"
 thiserror = "1.0"
 tokio = "1.8"
 tonic = "0.5"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The application accepts the following parameters:
 
 ```shell
 docker build \
-  --build-arg=build_image=rust:1.53-slim-buster \
+  --build-arg=build_image=rust:1.54-slim-buster \
   --build-arg=base_image=debian:buster-slim \
   --tag=concordium-rosetta \
   --pull \

--- a/macos.Jenkinsfile
+++ b/macos.Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
             steps {
                 sh '''\
                     # Set up Rust toolchain.
-                    rustup default 1.53
+                    rustup default 1.54 # TODO parameterize
 
                     # Build binary and run it to get version.
                     version="$(cargo run --release -- --version | awk '{print $2}')"

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use rosetta::models::NetworkIdentifier;
 #[clap(
     author = "Concordium Foundation",
     about = "A server implementing the Rosetta API for the Concordium blockchain.",
-    version,
+    version
 )]
 struct Args {
     #[clap(
@@ -37,28 +37,28 @@ struct Args {
         long = "port",
         env = "PORT",
         help = "The port that HTTP requests are to be served on.",
-        default_value = "8080",
+        default_value = "8080"
     )]
     port:       u16,
     #[clap(
         long = "grpc-host",
         env = "GRPC_HOST",
         help = "Hostname or IP of the node's gRPC endpoint.",
-        default_value = "localhost",
+        default_value = "localhost"
     )]
     grpc_host:  String,
     #[clap(
         long = "grpc-port",
         env = "GRPC_PORT",
         help = "Port of the node's gRPC endpoint.",
-        default_value = "10000",
+        default_value = "10000"
     )]
     grpc_port:  u16,
     #[clap(
         long = "grpc-token",
         env = "GRPC_TOKEN",
         help = "Access token of the node's gRPC endpoint.",
-        default_value = "rpcadmin",
+        default_value = "rpcadmin"
     )]
     grpc_token: String,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,42 +13,47 @@ use crate::{
     validate::{account::AccountValidator, network::NetworkValidator},
 };
 use anyhow::{Context, Result};
-use clap::AppSettings;
+use clap::Parser;
 use concordium_rust_sdk::endpoints::Client;
 use env_logger::{Builder, Env};
 use rosetta::models::NetworkIdentifier;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
-struct App {
-    #[structopt(
+#[derive(Parser, Debug)]
+#[clap(
+    author = "Concordium Foundation",
+    about = "A server implementing the Rosetta API for the Concordium blockchain."
+)]
+struct Args {
+    #[clap(
         long = "network",
+        env = "NETWORK",
         help = "The name of the network that the connected node is part of; i.e. 'testnet' or \
                 'mainnet'. Only requests with network identifier using this value will be \
                 accepted (see docs for details)."
     )]
     network:    String,
-    #[structopt(
+    #[clap(
         long = "port",
+        env = "PORT",
         help = "The port that HTTP requests are to be served on.",
         default_value = "8080"
     )]
     port:       u16,
-    #[structopt(
+    #[clap(
         long = "grpc-host",
         env = "GRPC_HOST",
         help = "Hostname or IP of the node's gRPC endpoint.",
         default_value = "localhost"
     )]
     grpc_host:  String,
-    #[structopt(
+    #[clap(
         long = "grpc-port",
         env = "GRPC_PORT",
         help = "Port of the node's gRPC endpoint.",
         default_value = "10000"
     )]
     grpc_port:  u16,
-    #[structopt(
+    #[clap(
         long = "grpc-token",
         env = "GRPC_TOKEN",
         help = "Access token of the node's gRPC endpoint.",
@@ -60,11 +65,7 @@ struct App {
 #[tokio::main]
 async fn main() -> Result<()> {
     // Parse CLI args.
-    let app = {
-        let app = App::clap().global_setting(AppSettings::ColoredHelp);
-        let matches = app.get_matches();
-        App::from_clap(&matches)
-    };
+    let args = Args::parse();
 
     // Initialize logging.
     Builder::from_env(Env::default().default_filter_or("info")).init();
@@ -72,16 +73,16 @@ async fn main() -> Result<()> {
     // Initialize gRPC and client.
     let endpoint = tonic::transport::Endpoint::from_shared(format!(
         "http://{}:{}",
-        app.grpc_host, app.grpc_port
+        args.grpc_host, args.grpc_port
     ))
     .context("invalid host and/or port")?;
     let client =
-        Client::connect(endpoint, app.grpc_token).await.context("cannot connect to node")?;
+        Client::connect(endpoint, args.grpc_token).await.context("cannot connect to node")?;
 
     // Set up handlers.
     let network_validator = NetworkValidator::new(NetworkIdentifier {
         blockchain:             "concordium".to_string(),
-        network:                app.network,
+        network:                args.network,
         sub_network_identifier: None,
     });
     let account_validator = AccountValidator {};
@@ -94,7 +95,7 @@ async fn main() -> Result<()> {
 
     // Configure and start web server.
     warp::serve(route::root(network_api, account_api, block_api, construction_api))
-        .run(([0, 0, 0, 0], app.port))
+        .run(([0, 0, 0, 0], args.port))
         .await;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,8 @@ use rosetta::models::NetworkIdentifier;
 #[derive(Parser, Debug)]
 #[clap(
     author = "Concordium Foundation",
-    about = "A server implementing the Rosetta API for the Concordium blockchain."
+    about = "A server implementing the Rosetta API for the Concordium blockchain.",
+    version,
 )]
 struct Args {
     #[clap(
@@ -36,28 +37,28 @@ struct Args {
         long = "port",
         env = "PORT",
         help = "The port that HTTP requests are to be served on.",
-        default_value = "8080"
+        default_value = "8080",
     )]
     port:       u16,
     #[clap(
         long = "grpc-host",
         env = "GRPC_HOST",
         help = "Hostname or IP of the node's gRPC endpoint.",
-        default_value = "localhost"
+        default_value = "localhost",
     )]
     grpc_host:  String,
     #[clap(
         long = "grpc-port",
         env = "GRPC_PORT",
         help = "Port of the node's gRPC endpoint.",
-        default_value = "10000"
+        default_value = "10000",
     )]
     grpc_port:  u16,
     #[clap(
         long = "grpc-token",
         env = "GRPC_TOKEN",
         help = "Access token of the node's gRPC endpoint.",
-        default_value = "rpcadmin"
+        default_value = "rpcadmin",
     )]
     grpc_token: String,
 }

--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
             steps {
                 sh '''\
                     # Set up Rust toolchain.
-                    rustup default 1.53-x86_64-pc-windows-gnu
+                    rustup default 1.54-x86_64-pc-windows-gnu # TODO parameterize
 
                     # Build binary and run it to get version.
                     version="$(cargo run --release -- --version | awk '{print $2}')"


### PR DESCRIPTION
## Purpose

As `clap` v3 is on par with or better than `structopt`, that project [has entered maintenance mode](https://github.com/TeXitoi/structopt#maintenance) and will not have things like the weird way it handles env vars fixed.

## Changes

Upgraded `clap` to v. `3.1` and removed dependency on `structopt`.