### PR TITLE
Error descriptions have to be non-empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog for concordium-client
+
+## 0.1.1
+- fix bug where an error description was empty.
+
+## 0.1.0 
+
+- initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog for concordium-client
+# Changelog
 
 ## 0.1.1
 - fix bug where an error description was empty.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rosetta"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-rosetta"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/handler_error.rs
+++ b/src/handler_error.rs
@@ -225,7 +225,7 @@ pub fn invalid_input_unsupported_value_error(name: Option<String>, value: Option
     Error {
         code:        1300,
         message:     "invalid input: unsupported value".to_string(),
-        description: Some("".to_string()),
+        description: Some("The provided input value is not supported.".to_string()),
         retriable:   false,
         details:     key_value_pairs(&[
             key_value_pair("name", name),


### PR DESCRIPTION
## Purpose

The rosetta-cli tool checks that error descriptions are not empty, which presumably means that is part of the API.

## Changes

Add an error description string to conform to the API.