### PR TITLE
Generate Allow type with correct field types

### DIFF
--- a/fmt.sh
+++ b/fmt.sh
@@ -1,0 +1,1 @@
+cargo +nightly-2021-06-09 fmt

--- a/fmt.sh
+++ b/fmt.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env sh
+
 cargo +nightly-2021-06-09 fmt

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
     "generate": "openapi-generator-cli generate --input-spec=./rosetta-specifications/api.yaml --generator-name=rust --output=rosetta --additional-properties=packageName=rosetta"
   },
   "devDependencies": {
-    "@openapitools/openapi-generator-cli": "^2.4.25"
+    "@openapitools/openapi-generator-cli": "^2.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
     "generate": "openapi-generator-cli generate --input-spec=./rosetta-specifications/api.yaml --generator-name=rust --output=rosetta --additional-properties=packageName=rosetta"
   },
   "devDependencies": {
-    "@openapitools/openapi-generator-cli": "^2.5.1"
+    "@openapitools/openapi-generator-cli": "^2.4.25"
   }
 }

--- a/rosetta/docs/Allow.md
+++ b/rosetta/docs/Allow.md
@@ -4,15 +4,13 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**operation_statuses** | [**Vec<serde_json::Value>**](serde_json::Value.md) | All Operation.Status this implementation supports. Any status that is returned during parsing that is not listed here will cause client validation to error.  | 
+**operation_statuses** | [**Vec<crate::models::OperationStatus>**](OperationStatus.md) | All Operation.Status this implementation supports. Any status that is returned during parsing that is not listed here will cause client validation to error.  | 
 **operation_types** | **Vec<String>** | All Operation.Type this implementation supports. Any type that is returned during parsing that is not listed here will cause client validation to error.  | 
-**errors** | [**Vec<serde_json::Value>**](serde_json::Value.md) | All Errors that this implementation could return. Any error that is returned during parsing that is not listed here will cause client validation to error.  | 
+**errors** | [**Vec<crate::models::Error>**](Error.md) | All Errors that this implementation could return. Any error that is returned during parsing that is not listed here will cause client validation to error.  | 
 **historical_balance_lookup** | **bool** | Any Rosetta implementation that supports querying the balance of an account at any height in the past should set this to true.  | 
 **timestamp_start_index** | Option<**i64**> | If populated, `timestamp_start_index` indicates the first block index where block timestamps are considered valid (i.e. all blocks less than `timestamp_start_index` could have invalid timestamps). This is useful when the genesis block (or blocks) of a network have timestamp 0.  If not populated, block timestamps are assumed to be valid for all available blocks.  | [optional]
 **call_methods** | **Vec<String>** | All methods that are supported by the /call endpoint. Communicating which parameters should be provided to /call is the responsibility of the implementer (this is en lieu of defining an entire type system and requiring the implementer to define that in Allow).  | 
-**balance_exemptions** | [**Vec<serde_json::Value>**](serde_json::Value.md) | BalanceExemptions is an array of BalanceExemption indicating which account balances could change without a corresponding Operation.  BalanceExemptions should be used sparingly as they may introduce significant complexity for integrators that attempt to reconcile all account balance changes.  If your implementation relies on any BalanceExemptions, you MUST implement historical balance lookup (the ability to query an account balance at any BlockIdentifier).  | 
+**balance_exemptions** | [**Vec<crate::models::BalanceExemption>**](BalanceExemption.md) | BalanceExemptions is an array of BalanceExemption indicating which account balances could change without a corresponding Operation.  BalanceExemptions should be used sparingly as they may introduce significant complexity for integrators that attempt to reconcile all account balance changes.  If your implementation relies on any BalanceExemptions, you MUST implement historical balance lookup (the ability to query an account balance at any BlockIdentifier).  | 
 **mempool_coins** | **bool** | Any Rosetta implementation that can update an AccountIdentifier's unspent coins based on the contents of the mempool should populate this field as true. If false, requests to `/account/coins` that set `include_mempool` as true will be automatically rejected.  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
-
-

--- a/rosetta/src/models/allow.rs
+++ b/rosetta/src/models/allow.rs
@@ -16,13 +16,13 @@
 pub struct Allow {
     /// All Operation.Status this implementation supports. Any status that is returned during parsing that is not listed here will cause client validation to error. 
     #[serde(rename = "operation_statuses")]
-    pub operation_statuses: Vec<serde_json::Value>,
+    pub operation_statuses: Vec<crate::models::OperationStatus>,
     /// All Operation.Type this implementation supports. Any type that is returned during parsing that is not listed here will cause client validation to error. 
     #[serde(rename = "operation_types")]
     pub operation_types: Vec<String>,
     /// All Errors that this implementation could return. Any error that is returned during parsing that is not listed here will cause client validation to error. 
     #[serde(rename = "errors")]
-    pub errors: Vec<serde_json::Value>,
+    pub errors: Vec<crate::models::Error>,
     /// Any Rosetta implementation that supports querying the balance of an account at any height in the past should set this to true. 
     #[serde(rename = "historical_balance_lookup")]
     pub historical_balance_lookup: bool,
@@ -34,7 +34,7 @@ pub struct Allow {
     pub call_methods: Vec<String>,
     /// BalanceExemptions is an array of BalanceExemption indicating which account balances could change without a corresponding Operation.  BalanceExemptions should be used sparingly as they may introduce significant complexity for integrators that attempt to reconcile all account balance changes.  If your implementation relies on any BalanceExemptions, you MUST implement historical balance lookup (the ability to query an account balance at any BlockIdentifier). 
     #[serde(rename = "balance_exemptions")]
-    pub balance_exemptions: Vec<serde_json::Value>,
+    pub balance_exemptions: Vec<crate::models::BalanceExemption>,
     /// Any Rosetta implementation that can update an AccountIdentifier's unspent coins based on the contents of the mempool should populate this field as true. If false, requests to `/account/coins` that set `include_mempool` as true will be automatically rejected. 
     #[serde(rename = "mempool_coins")]
     pub mempool_coins: bool,
@@ -42,7 +42,7 @@ pub struct Allow {
 
 impl Allow {
     /// Allow specifies supported Operation status, Operation types, and all possible error statuses. This Allow object is used by clients to validate the correctness of a Rosetta Server implementation. It is expected that these clients will error if they receive some response that contains any of the above information that is not specified here. 
-    pub fn new(operation_statuses: Vec<serde_json::Value>, operation_types: Vec<String>, errors: Vec<serde_json::Value>, historical_balance_lookup: bool, call_methods: Vec<String>, balance_exemptions: Vec<serde_json::Value>, mempool_coins: bool) -> Allow {
+    pub fn new(operation_statuses: Vec<crate::models::OperationStatus>, operation_types: Vec<String>, errors: Vec<crate::models::Error>, historical_balance_lookup: bool, call_methods: Vec<String>, balance_exemptions: Vec<crate::models::BalanceExemption>, mempool_coins: bool) -> Allow {
         Allow {
             operation_statuses,
             operation_types,
@@ -55,5 +55,3 @@ impl Allow {
         }
     }
 }
-
-

--- a/src/api/network.rs
+++ b/src/api/network.rs
@@ -1,8 +1,5 @@
 use crate::{
-    api::{
-        error::ApiResult,
-        transaction::*,
-    },
+    api::{error::ApiResult, transaction::*},
     handler_error,
     validate::network::NetworkValidator,
     QueryHelper,
@@ -44,11 +41,11 @@ impl NetworkApi {
             allow:   Box::new(Allow {
                 operation_statuses:        vec![
                     OperationStatus {
-                        status: OPERATION_STATUS_OK.to_string(),
+                        status:     OPERATION_STATUS_OK.to_string(),
                         successful: true,
                     },
                     OperationStatus {
-                        status: OPERATION_STATUS_FAIL.to_string(),
+                        status:     OPERATION_STATUS_FAIL.to_string(),
                         successful: false,
                     },
                 ],
@@ -79,10 +76,12 @@ impl NetworkApi {
                     OPERATION_TYPE_UPDATE_CREDENTIALS.to_string(),
                     OPERATION_TYPE_REGISTER_DATA.to_string(),
                 ],
-                errors: vec![
+                errors:                    vec![
                     handler_error::invalid_input_unsupported_field_error(None),
                     handler_error::invalid_input_missing_field_error(None),
-                    handler_error::invalid_input_invalid_value_or_identifier_error(None, None, None, None),
+                    handler_error::invalid_input_invalid_value_or_identifier_error(
+                        None, None, None, None,
+                    ),
                     handler_error::invalid_input_unsupported_value_error(None, None),
                     handler_error::invalid_input_inconsistent_value_error(None, None),
                     handler_error::identifier_not_resolved_no_matches_error(None),

--- a/src/api/network.rs
+++ b/src/api/network.rs
@@ -1,6 +1,6 @@
 use crate::{
     api::{
-        error::{ApiError, ApiResult},
+        error::ApiResult,
         transaction::*,
     },
     handler_error,
@@ -43,8 +43,14 @@ impl NetworkApi {
             }),
             allow:   Box::new(Allow {
                 operation_statuses:        vec![
-                    json!({ "status": OPERATION_STATUS_OK, "successful": true }),
-                    json!({ "status": OPERATION_STATUS_FAIL, "successful": false }),
+                    OperationStatus {
+                        status: OPERATION_STATUS_OK.to_string(),
+                        successful: true,
+                    },
+                    OperationStatus {
+                        status: OPERATION_STATUS_FAIL.to_string(),
+                        successful: false,
+                    },
                 ],
                 operation_types:           vec![
                     OPERATION_TYPE_FEE.to_string(),
@@ -73,8 +79,18 @@ impl NetworkApi {
                     OPERATION_TYPE_UPDATE_CREDENTIALS.to_string(),
                     OPERATION_TYPE_REGISTER_DATA.to_string(),
                 ],
-                errors:                    errors()
-                    .map_err(|err| ApiError::JsonEncodingFailed("errors".to_string(), err))?,
+                errors: vec![
+                    handler_error::invalid_input_unsupported_field_error(None),
+                    handler_error::invalid_input_missing_field_error(None),
+                    handler_error::invalid_input_invalid_value_or_identifier_error(None, None, None, None),
+                    handler_error::invalid_input_unsupported_value_error(None, None),
+                    handler_error::invalid_input_inconsistent_value_error(None, None),
+                    handler_error::identifier_not_resolved_no_matches_error(None),
+                    handler_error::identifier_not_resolved_multiple_matches_error(None),
+                    handler_error::proxy_client_rpc_error(None),
+                    handler_error::proxy_client_query_error(None),
+                    handler_error::proxy_transaction_rejected(),
+                ],
                 historical_balance_lookup: true,
                 timestamp_start_index:     None, /* not populated as the genesis block has a
                                                   * valid time stamp */
@@ -116,23 +132,4 @@ impl NetworkApi {
                 .collect(),
         })
     }
-}
-
-fn errors() -> Result<Vec<serde_json::Value>, serde_json::Error> {
-    error_types().iter().map(serde_json::to_value).collect()
-}
-
-fn error_types() -> Vec<Error> {
-    vec![
-        handler_error::invalid_input_unsupported_field_error(None),
-        handler_error::invalid_input_missing_field_error(None),
-        handler_error::invalid_input_invalid_value_or_identifier_error(None, None, None, None),
-        handler_error::invalid_input_unsupported_value_error(None, None),
-        handler_error::invalid_input_inconsistent_value_error(None, None),
-        handler_error::identifier_not_resolved_no_matches_error(None),
-        handler_error::identifier_not_resolved_multiple_matches_error(None),
-        handler_error::proxy_client_rpc_error(None),
-        handler_error::proxy_client_query_error(None),
-        handler_error::proxy_transaction_rejected(),
-    ]
 }


### PR DESCRIPTION
## Purpose

Make fields of generated struct use the correct types. 

## Changes

Picked changes to generated `Allow` type from version generated by a more recent version of the rosetta spec.

It seems like there's some bug in the generator that makes it generate fields of type plain `serde_json::Value` instead of the proper types in the `Allow` struct. Picking the changes to `Allow`'s model from commit https://github.com/coinbase/rosetta-specifications/commit/ce6898659de0f79c350034db6ac938e12805302f#diff-80521b2ac2125e10a84393ae746d6f0d993979c8a974dc320b913f8bb2fd32b5 makes it generate it correctly. Before the model change, all non-builtin types were used as a parameter to `Vec`, so that could be what's triggering the bug.

This also means that this change won't be reverted by a future upgrade of the Rosetta spec.