### PR TITLE
Respond with non-OK HTTP status codes on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 0.2.0
+
+- Respond with non-OK HTTP status codes on error.
+
 ## 0.1.1
-- fix bug where an error description was empty.
+
+- Fix bug where an error description was empty.
 
 ## 0.1.0 
 
-- initial release
+- Initial release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rosetta"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-rosetta"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ No prefixes such as "0x" may be added.
 ### Operations
 
 Rosetta represents transactions as a list of operations,
-each of which indicate that the balance of some account has changed for some reason.
+each of which usually indicate that the balance of some account has changed for some reason.
 
 Transactions with memo are represented as the same operation types as the ones without memo.
 The memo is simply included as metadata if the transaction contains one.
@@ -216,6 +216,12 @@ Transaction types are otherwise represented by operation types named after the t
 For consistency, operation type names are styled with snake_case.
 
 The Construction API only supports operations of type `transfer`.
+
+### Errors
+
+All success responses are returned with an HTTP 200 message.
+Errors are returned with an appropriate 4xx code if they're the result of by client input.
+Errors propagated from the SDK are given a 5xx code.
 
 ## Examples
 
@@ -227,7 +233,7 @@ The transfer may optionally include a memo.
 
 ### Example
 
-Transfer 1000 µCCD along with a memo from account
+Transfer 1000 µCCD along with a memo from testnet account
 `3rsc7HNLVKnFz9vmKkAaEMVpNkFA4hZxJpZinCtUTJbBh58yYi` to `4Gaw3Y44fyGzaNbG69eZyr1Q5fByMvSuQ5pKRW7xRmDzajKtMS`
 
 The command for doing this using the client is
@@ -524,12 +530,12 @@ The request/response flow of the command is a sequence of calls to the Construct
 
 ### Failure handling
 
-Rosetta doesn't check most things that would make a transaction invalid;
+Rosetta doesn't check most causes of transactions being invalid;
 i.e. things like nonexistent accounts, bad signatures, and insufficient funds.
 As long as the transaction is "well-formed", Rosetta will accept the transaction and return its hash
 without complaints.
 
-The exception to this is if the sender account doesn't exist.
+An exception to this is if the sender account doesn't exist.
 Then the nonce lookup will fail and result in an error.
 
 Depending on the situation, a submitted invalid transaction may or may not ever get included in a block.

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The Construction API only supports operations of type `transfer`.
 ### Errors
 
 All success responses are returned with an HTTP 200 message.
-Errors are returned with an appropriate 4xx code if they're the result of by client input.
+Errors are returned with an appropriate 4xx code if they're the result of the client input.
 Errors propagated from the SDK are given a 5xx code.
 
 ## Examples

--- a/tools/transfer-client/README.md
+++ b/tools/transfer-client/README.md
@@ -58,6 +58,7 @@ in the app and transfer the export file `concordium-backup.concordiumwallet` to 
 
 Then decrypt the export using [utils](https://developer.concordium.software/en/mainnet/net/references/developer-tools.html#decrypt-encrypted-output)
 and extract the key portion using [jq](https://stedolan.github.io/jq/), e.g.:
+
 ```shell
 $ utils decrypt --in concordium-backup.concordiumwallet | \
    jq '.value.identities[0].accounts[0].accountKeys' > sender.keys
@@ -66,5 +67,4 @@ $ utils decrypt --in concordium-backup.concordiumwallet | \
 
 The keys are now stored in clear text in the file `sender.keys`.
 
-This is only intended to be used for testing.
-Keys holding actual value should always be stored securely.
+This is only intended to be used for testing - keys holding actual value should always be stored securely.


### PR DESCRIPTION
## Purpose

Make it easier for clients to understand when the response is an error. Currently they can only do it by parsing the JSON payload.

## Changes

Respond with non-OK HTTP status codes on error. The status code also includes a hint on what kind of error it is.

Resolves #14.