### PR TITLE
Ensure that all amount casts are sound

### DIFF
--- a/src/api/account.rs
+++ b/src/api/account.rs
@@ -41,7 +41,7 @@ impl AccountApi {
                 block_info.block_height.height as i64,
                 block_info.block_hash.to_string(),
             ),
-            vec![amount_from_uccd(account_info.account_amount.microgtu as i64)],
+            vec![amount_from_uccd(account_info.account_amount.microgtu as i128)],
         ))
     }
 }

--- a/src/api/amount.rs
+++ b/src/api/amount.rs
@@ -5,11 +5,11 @@ use crate::{
 use rosetta::models::{Amount, Currency};
 use std::ops::Deref;
 
-pub fn amount_from_uccd(v: i64) -> Amount {
+pub fn amount_from_uccd(v: i128) -> Amount {
     Amount::new(v.to_string(), Currency::new("CCD".to_string(), 6))
 }
 
-pub fn uccd_from_amount(v: &Amount) -> ApiResult<i64> {
+pub fn uccd_from_amount(v: &Amount) -> ApiResult<i128> {
     validate_currency(v.currency.deref())?;
     v.value.parse().map_err(|_| ApiError::InvalidAmount(v.value.clone()))
 }

--- a/src/api/block.rs
+++ b/src/api/block.rs
@@ -228,9 +228,7 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                     account:              Some(Box::new(AccountIdentifier::new(
                         ACCOUNT_BAKING_REWARD.to_string(),
                     ))),
-                    amount:               Some(Box::new(amount_from_uccd(
-                        -baking_reward_sum,
-                    ))),
+                    amount:               Some(Box::new(amount_from_uccd(-baking_reward_sum))),
                     coin_change:          None,
                     metadata:             None,
                 })

--- a/src/api/block.rs
+++ b/src/api/block.rs
@@ -197,10 +197,10 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                 baker_rewards,
                 ..
             } => {
-                let mut baking_reward_sum: u64 = 0;
+                let mut baking_reward_sum: i128 = 0;
                 let mut operation_identifiers = vec![];
                 for (baker_account_address, amount) in baker_rewards {
-                    baking_reward_sum += amount.microgtu;
+                    baking_reward_sum += amount.microgtu as i128;
                     let id = OperationIdentifier::new(next_index(&mut index_offset));
                     operation_identifiers.push(id.clone());
                     res.push(Operation {
@@ -229,7 +229,7 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                         ACCOUNT_BAKING_REWARD.to_string(),
                     ))),
                     amount:               Some(Box::new(amount_from_uccd(
-                        -(baking_reward_sum as i128),
+                        -baking_reward_sum,
                     ))),
                     coin_change:          None,
                     metadata:             None,
@@ -239,10 +239,10 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                 finalization_rewards,
                 ..
             } => {
-                let mut finalization_reward_sum: u64 = 0;
+                let mut finalization_reward_sum: i128 = 0;
                 let mut operation_identifiers = vec![];
                 for (baker_account_address, amount) in finalization_rewards {
-                    finalization_reward_sum += amount.microgtu;
+                    finalization_reward_sum += amount.microgtu as i128;
                     let id = OperationIdentifier {
                         index:         next_index(&mut index_offset),
                         network_index: None,
@@ -274,7 +274,7 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                         ACCOUNT_FINALIZATION_REWARD.to_string(),
                     ))),
                     amount:               Some(Box::new(amount_from_uccd(
-                        -(finalization_reward_sum as i128),
+                        -finalization_reward_sum,
                     ))),
                     coin_change:          None,
                     metadata:             None,

--- a/src/api/block.rs
+++ b/src/api/block.rs
@@ -108,7 +108,7 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                         "baking_reward_account".to_string(),
                     ))),
                     amount:               Some(Box::new(amount_from_uccd(
-                        mint_baking_reward.microgtu as i64,
+                        mint_baking_reward.microgtu as i128,
                     ))),
                     coin_change:          None,
                     metadata:             None,
@@ -124,7 +124,7 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                         "finalization_reward_account".to_string(),
                     ))),
                     amount:               Some(Box::new(amount_from_uccd(
-                        mint_finalization_reward.microgtu as i64,
+                        mint_finalization_reward.microgtu as i128,
                     ))),
                     coin_change:          None,
                     metadata:             None,
@@ -141,7 +141,7 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                         foundation_account.to_string(),
                     ))),
                     amount:               Some(Box::new(amount_from_uccd(
-                        mint_platform_development_charge.microgtu as i64,
+                        mint_platform_development_charge.microgtu as i128,
                     ))),
                     coin_change:          None,
                     metadata:             None,
@@ -168,7 +168,7 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                             baker.to_string(),
                         ))),
                         amount:               Some(Box::new(amount_from_uccd(
-                            baker_reward.microgtu as i64,
+                            baker_reward.microgtu as i128,
                         ))),
                         coin_change:          None,
                         metadata:             None,
@@ -186,7 +186,7 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                             foundation_account.to_string(),
                         ))),
                         amount:               Some(Box::new(amount_from_uccd(
-                            foundation_charge.microgtu as i64,
+                            foundation_charge.microgtu as i128,
                         ))),
                         coin_change:          None,
                         metadata:             None,
@@ -212,7 +212,7 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                             baker_account_address.to_string(),
                         ))),
                         amount:               Some(Box::new(amount_from_uccd(
-                            amount.microgtu as i64,
+                            amount.microgtu as i128,
                         ))),
                         coin_change:          None,
                         metadata:             None,
@@ -229,7 +229,7 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                         ACCOUNT_BAKING_REWARD.to_string(),
                     ))),
                     amount:               Some(Box::new(amount_from_uccd(
-                        -(baking_reward_sum as i64),
+                        -(baking_reward_sum as i128),
                     ))),
                     coin_change:          None,
                     metadata:             None,
@@ -257,7 +257,7 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                             baker_account_address.to_string(),
                         ))),
                         amount:               Some(Box::new(amount_from_uccd(
-                            amount.microgtu as i64,
+                            amount.microgtu as i128,
                         ))),
                         coin_change:          None,
                         metadata:             None,
@@ -274,7 +274,7 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                         ACCOUNT_FINALIZATION_REWARD.to_string(),
                     ))),
                     amount:               Some(Box::new(amount_from_uccd(
-                        -(finalization_reward_sum as i64),
+                        -(finalization_reward_sum as i128),
                     ))),
                     coin_change:          None,
                     metadata:             None,

--- a/src/api/construction.rs
+++ b/src/api/construction.rs
@@ -54,7 +54,7 @@ struct PayloadRequestMetadata {
 
 struct ParsedTransferOperation {
     account_address: AccountAddress,
-    amount_uccd:     i64,
+    amount_uccd:     i128,
 }
 
 enum ParsedOperation {
@@ -424,7 +424,7 @@ fn parse_transfer_transaction(
     Ok(ParsedTransaction::Transfer(ParsedTransferTransaction {
         sender_address:   sender.account_address,
         receiver_address: receiver.account_address,
-        amount_uccd:      receiver.amount_uccd as u64,
+        amount_uccd:      receiver.amount_uccd as u64, // casting from positive i64 to u64
     }))
 }
 
@@ -461,7 +461,7 @@ fn operations_from_transaction(
         } => operations_from_transfer_transaction(
             &header.sender,
             to_address,
-            amount.microgtu as i64,
+            amount.microgtu as i128,
             None,
         ),
         Payload::TransferWithMemo {
@@ -471,7 +471,7 @@ fn operations_from_transaction(
         } => operations_from_transfer_transaction(
             &header.sender,
             to_address,
-            amount.microgtu as i64,
+            amount.microgtu as i128,
             Some(memo.clone()),
         ),
         _ => Err(ApiError::UnsupportedOperationType(transaction_type_to_operation_type(Some(
@@ -483,7 +483,7 @@ fn operations_from_transaction(
 fn operations_from_transfer_transaction(
     sender_addr: &AccountAddress,
     receiver_addr: &AccountAddress,
-    amount_uccd: i64,
+    amount_uccd: i128,
     memo: Option<Memo>,
 ) -> ApiResult<(Vec<Operation>, Option<Memo>)> {
     Ok((

--- a/src/api/transaction.rs
+++ b/src/api/transaction.rs
@@ -202,7 +202,7 @@ pub fn map_transaction(info: &BlockItemSummary) -> Transaction {
                     details.sender.to_string(),
                 ))),
                 amount:               Some(Box::new(amount_from_uccd(
-                    -(details.cost.microgtu as i64),
+                    -(details.cost.microgtu as i128),
                 ))),
                 coin_change:          None,
                 metadata:             None,
@@ -243,7 +243,7 @@ fn operations_and_metadata_from_account_transaction_details(
                     details.sender.to_string(),
                 ))),
                 amount:               Some(Box::new(amount_from_uccd(
-                    details.cost.microgtu as i64,
+                    details.cost.microgtu as i128,
                 ))),
                 coin_change:          None,
                 metadata:             Some(
@@ -563,14 +563,14 @@ fn simple_transfer_operations(
         0,
         details,
         details.sender.to_string(),
-        Some(amount_from_uccd(-(amount.microgtu as i64))),
+        Some(amount_from_uccd(-(amount.microgtu as i128))),
         None,
     );
     let mut receiver_operation = account_transaction_operation::<Value>(
         1,
         details,
         to.to_string(),
-        Some(amount_from_uccd(amount.microgtu as i64)),
+        Some(amount_from_uccd(amount.microgtu as i128)),
         None,
     );
     receiver_operation.related_operations =
@@ -615,7 +615,7 @@ fn normal_account_transaction_operation<T: SerdeSerialize>(
     metadata: Option<&T>,
 ) -> Operation {
     let account_address = details.sender.to_string();
-    let amount = amount_from_uccd(details.cost.microgtu as i64);
+    let amount = amount_from_uccd(details.cost.microgtu as i128);
     account_transaction_operation(index, details, account_address, Some(amount), metadata)
 }
 


### PR DESCRIPTION
## Purpose

The currently used type `i64` is wide enough for the time being but may not be so in the distant future. Using `i128` instead ensures that any `u64` value stays represented correctly.

## Changes

Change all `i64` variables for amounts to `i128`.

Rosetta represents amounts as strings so no changes to generated code are required.

Requested in [this comment](https://github.com/Concordium/concordium-rosetta/pull/18/files#r864980096).