### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,10 +524,25 @@ The request/response flow of the command is a sequence of calls to the Construct
 
 ### Failure handling
 
-Rosetta doesn't check things like the sender of a transfer transaction having sufficient funds.
-Instead, the transaction will be sent successfully and applied in a failed state where only the fee is deducted.
+Rosetta doesn't check most things that would make a transaction invalid; things like
+nonexistent accounts, bad signatures, and insufficient funds.
+As long as the transaction is "well-formed", Rosetta will accept the transaction and return its hash
+without complaints.
 
-TODO...
+The exception to this is if the sender account doesn't exist.
+Then the nonce lookup will fail and result in an error.
+
+Depending on the situation, a submitted invalid transaction may or may not ever get included in a block.
+Generally speaking, if the transaction is signed correctly and the sender is able to pay a fee,
+the transaction will be applied in a failed state. Otherwise it is silently rejected.
+
+For example, if the wrong keys are provided, then the transaction will silently disappear.
+If, on the other hand, the receiver doesn't exist or the sender has insufficient funds,
+then the only outcome of the transaction is an error message (and the deduction of a fee).
+
+The bottom line is that the only way to confirm that a transaction is successfully applied
+is to check the hash against the chain.
+Also, the block containing the transaction has to be finalized for the transaction to be as well.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The repository uses *recursive* git submodules. Make sure that all submodules ar
 git submodule update --init --recursive
 ```
 
-**IMPORTANT:** This must be done after the initial clone as well as after switching between branches.
+**IMPORTANT:** This must be done after the initial clone as well as after you've switched between branches.
 
 *Build*
 
@@ -521,6 +521,13 @@ The request/response flow of the command is a sequence of calls to the Construct
 
 9. The hash may be recomputed later (or before) with the `hash` endpoint,
    which is just a dry-run variant of `submit`.
+
+### Failure handling
+
+Rosetta doesn't check things like the sender of a transfer transaction having sufficient funds.
+Instead, the transaction will be sent successfully and applied in a failed state where only the fee is deducted.
+
+TODO...
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The server performs all on-chain activity against a [node](https://github.com/Co
 through its gRPC interface.
 
 The project is written in [Rust](https://www.rust-lang.org/) (minimum supported toolchain version is listed below).
-The best way to install the toolchain is via [rustup](https://rustup.rs/).
+A great way to install the toolchain is via [rustup](https://rustup.rs/).
 
 ### Versions
 
@@ -524,8 +524,8 @@ The request/response flow of the command is a sequence of calls to the Construct
 
 ### Failure handling
 
-Rosetta doesn't check most things that would make a transaction invalid; things like
-nonexistent accounts, bad signatures, and insufficient funds.
+Rosetta doesn't check most things that would make a transaction invalid;
+i.e. things like nonexistent accounts, bad signatures, and insufficient funds.
 As long as the transaction is "well-formed", Rosetta will accept the transaction and return its hash
 without complaints.
 
@@ -534,7 +534,7 @@ Then the nonce lookup will fail and result in an error.
 
 Depending on the situation, a submitted invalid transaction may or may not ever get included in a block.
 Generally speaking, if the transaction is signed correctly and the sender is able to pay a fee,
-the transaction will be applied in a failed state. Otherwise it is silently rejected.
+then the transaction will be applied in a failed state. Otherwise it is silently rejected.
 
 For example, if the wrong keys are provided, then the transaction will silently disappear.
 If, on the other hand, the receiver doesn't exist or the sender has insufficient funds,

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ All applicable endpoints are supported to construct and submit transfer transact
   Implemented, but doesn't serve any real purpose as the returned options are already known by the caller.
   The fields `max_fee` and `suggested_fee_multipler` are not supported as the fee of any transaction is deterministic
   and cannot be boosted to expedite the transaction.
-  All one can do is retrieving the fee from the output of `parse` and choose not to proceed if it's deemed too large.
+  All one can do is retrieve the fee from the output of `parse` and choose not to proceed if it's deemed too large.
   An error is returned if the operations don't form a valid transfer
   (i.e. a pair of operations of type "transfer" with zero-sum amounts and valid addresses etc.).
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The application accepts the following parameters:
 
 *Build*
 
-**IMPORTANT:** Before building, make sure that submodules are checked out correctly as described in the prerequisites section above.
+**IMPORTANT:** Before building, make sure that submodules are checked out correctly as described above.
 
 ```shell
 docker build \

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ through its gRPC interface.
 ### Versions
 
 - Rosetta spec version: 1.4.10.
-- Supported Concordium node version: 3.0.1.
+- Supported Concordium node version: 3.0.x.
 
 ## Build and run
 

--- a/README.md
+++ b/README.md
@@ -9,23 +9,26 @@ Any TLS connections must be terminated by a reverse proxy before the requests hi
 The server performs all on-chain activity against a [node](https://github.com/Concordium/concordium-node)
 through its gRPC interface.
 
+The project is written in [Rust](https://www.rust-lang.org/) (minimum supported toolchain version is listed below).
+The best way to install the toolchain is via [rustup](https://rustup.rs/).
+
 ### Versions
 
 - Rosetta spec version: 1.4.10.
 - Supported Concordium node version: 3.0.x.
+- Supported Rust toolchain version: 1.54+.
 
 ## Build and run
 
 *Prerequisites*
 
-This is a pure [Rust](https://www.rust-lang.org/) project, and at the moment the minimum supported rust version is 1.54.
-The best way to install the toolchain is via [rustup](https://rustup.rs/)
+The repository uses *recursive* git submodules. Make sure that all submodules are checked out correctly using
 
-This repository uses **recursive** git submodules. **Before building make sure that those are checked out**
 ```shell
 git submodule update --init --recursive
 ```
-this must also be done when changing branches.
+
+**IMPORTANT:** This must be done after the initial clone as well as after switching between branches.
 
 *Build*
 
@@ -41,15 +44,9 @@ The application accepts the following parameters:
 
 ### Docker
 
-*Prerequisites*
-
-This repository uses **recursive** git submodules. **Before building make sure that those are checked out**
-```shell
-git submodule update --init --recursive
-```
-this must also be done when changing branches.
-
 *Build*
+
+**IMPORTANT:** Before building, make sure that submodules are checked out correctly as described in the prerequisites section above.
 
 ```shell
 docker build \

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A great way to install the toolchain is via [rustup](https://rustup.rs/).
 
 *Prerequisites*
 
-The repository uses *recursive* git submodules. Make sure that all submodules are checked out correctly using
+The repository uses *nested* git submodules. Make sure that all submodules are checked out correctly using
 
 ```shell
 git submodule update --init --recursive
@@ -537,7 +537,7 @@ Generally speaking, if the transaction is signed correctly and the sender is abl
 then the transaction will be applied in a failed state. Otherwise it is silently rejected.
 
 For example, if the wrong keys are provided, then the transaction will silently disappear.
-If, on the other hand, the receiver doesn't exist or the sender has insufficient funds,
+If the receiver doesn't exist or the sender has insufficient funds,
 then the only outcome of the transaction is an error message (and the deduction of a fee).
 
 The bottom line is that the only way to confirm that a transaction is successfully applied

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ docker run --rm concordium-rosetta
 ## Rosetta
 
 Rosetta is a specification of an HTTP-based API designed by Coinbase
-to provide a common layer of abstraction for interacting with blockchains.
+to provide a common layer of abstraction for interacting with any blockchain.
 
 The Rosetta API is divided into three categories:
 
@@ -61,27 +61,27 @@ There are also mentions of a [Call API](https://www.rosetta-api.org/docs/CallApi
 but it doesn't appear to be a first class member of the spec.
 
 To learn more about the intended behavior and usage of the endpoints,
-see the [official documentation](https://www.rosetta-api.org/docs/welcome.html) or the example section below.
+see the [official documentation](https://www.rosetta-api.org/docs/welcome.html) and the example section below.
 
 ## Implementation status
 
-All required features of the Rosetta specification are implemented.
-I.e. everything that isn't implemented is marked as optional in the spec/docs.
+All required features of the Rosetta specification are implemented:
+Everything that isn't implemented is marked as optional in the spec/docs.
 
 The sections below outline the status for the individual endpoints along with details relevant to integrating Rosetta clients.
 
 ### Data API
 
 All applicable endpoints except for the
-[optional](https://www.rosetta-api.org/docs/all_methods.html) mempool ones supported:
+[optional](https://www.rosetta-api.org/docs/all_methods.html) mempool ones are supported:
 
 - [Network](https://www.rosetta-api.org/docs/NetworkApi.html):
   All endpoints (`list`, `status`, `options`) are implemented according to the specification.
 
 - [Account](https://www.rosetta-api.org/docs/AccountApi.html):
   The `balance` endpoint is implemented according to the specification.
-  The `coins` endpoint is not applicable as Concordium is account-,
-  not [UTXO](https://www.investopedia.com/terms/u/utxo.asp)-based,
+  The `coins` endpoint is not applicable as Concordium is account-based
+  (i.e. doesn't use [UTXO](https://www.investopedia.com/terms/u/utxo.asp)),
   and thus doesn't have this concept of "coins".
 
 - [Block](https://www.rosetta-api.org/docs/BlockApi.html):
@@ -105,10 +105,10 @@ All applicable endpoints are supported to construct and submit transfer transact
   Not applicable as account addresses aren't derivable from public keys.
 
 - [`preprocess`](https://www.rosetta-api.org/docs/ConstructionApi.html#constructionpreprocess):
-  Implemented, but doesn't really serve any real purpose as the returned options are already known by the caller.
+  Implemented, but doesn't serve any real purpose as the returned options are already known by the caller.
   The fields `max_fee` and `suggested_fee_multipler` are not supported as the fee of any transaction is deterministic
   and cannot be boosted to expedite the transaction.
-  One can get the fee from the output of `parse` and choose not to proceed if the fee is deemed too large.
+  All one can do is retrieving the fee from the output of `parse` and choose not to proceed if it's deemed too large.
   An error is returned if the operations don't form a valid transfer
   (i.e. a pair of operations of type "transfer" with zero-sum amounts and valid addresses etc.).
 

--- a/tools/transfer-client/README.md
+++ b/tools/transfer-client/README.md
@@ -23,5 +23,26 @@ The application has the following CLI parameters:
 - `--sender`: Address of the account sending the transfer.
 - `--receiver`: Address of the account receiving the transfer.
 - `--amount`: Amount of µCCD to transfer.
-- `--keys-file`: Path of file containing the signing keys for the sender account.
+- `--keys-file`: Path of JSON file containing the signing keys for the sender account.
 - `--memo-hex`: Optional hex-encoded memo to attach to the transfer transaction.
+
+The expected JSON format of the keys file is
+
+```
+{
+  "keys": {
+    <credential-index>: {
+      "keys": {
+        <key-index>: {
+          "signKey": ...,
+          "verifyKey": ...,
+        },
+        ...
+      },
+      "threshold": <key-threshold>
+    },
+    ...
+  },
+  "threshold": <credential-threshold>
+}
+```

--- a/tools/transfer-client/README.md
+++ b/tools/transfer-client/README.md
@@ -46,3 +46,25 @@ The expected JSON format of the keys file is
   "threshold": <credential-threshold>
 }
 ```
+
+## Extracting keys from Mobile Wallet
+
+The tool expects account keys to be provided in plain text.
+The mobile wallet only allows keys to be exported with password protected encryption.
+To use keys exported from a wallet, they therefore first need to be decrypted and extracted as follows:
+
+First [create an export](https://developer.concordium.software/en/mainnet/net/mobile-wallet/export-import-mw.html)
+in the app and transfer the export file `concordium-backup.concordiumwallet` to your PC.
+
+Then decrypt the export using [utils](https://developer.concordium.software/en/mainnet/net/references/developer-tools.html#decrypt-encrypted-output)
+and extract the keys using [jq](https://stedolan.github.io/jq/), e.g.:
+```shell
+$ utils decrypt --in concordium-backup.concordiumwallet | \
+   jq '.value.identities[0].accounts[0].accountKeys' > sender.keys
+# enter password
+```
+
+The keys are now stored in clear text in the file `sender.keys`.
+
+Of course, keys holding actual value should never be stored in clear text on the disk.
+This is only intended to be used for testing. Appropriate changes should be made to the tool to handle encrypted keys.

--- a/tools/transfer-client/README.md
+++ b/tools/transfer-client/README.md
@@ -66,5 +66,5 @@ $ utils decrypt --in concordium-backup.concordiumwallet | \
 
 The keys are now stored in clear text in the file `sender.keys`.
 
-Of course, keys holding actual value should never be stored in clear text on the disk.
-This is only intended to be used for testing. Appropriate changes should be made to the tool to handle encrypted keys.
+This is only intended to be used for testing.
+Keys holding actual value should always be stored securely.

--- a/tools/transfer-client/README.md
+++ b/tools/transfer-client/README.md
@@ -57,7 +57,7 @@ First [create an export](https://developer.concordium.software/en/mainnet/net/mo
 in the app and transfer the export file `concordium-backup.concordiumwallet` to your PC.
 
 Then decrypt the export using [utils](https://developer.concordium.software/en/mainnet/net/references/developer-tools.html#decrypt-encrypted-output)
-and extract the keys using [jq](https://stedolan.github.io/jq/), e.g.:
+and extract the key portion using [jq](https://stedolan.github.io/jq/), e.g.:
 ```shell
 $ utils decrypt --in concordium-backup.concordiumwallet | \
    jq '.value.identities[0].accounts[0].accountKeys' > sender.keys


### PR DESCRIPTION
## Purpose

Improve documentation, particularly on failure handling.

## Changes

Gave a pass on the root README and added a section on how Rosetta handles and not handles failure with examples.

Also added a section to the README of the `transfer-client` tool on how to use keys exported from the mobile wallet.

Resolves #12.