### PR TITLE
Ensure that all operations emit correct amounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.3
+
+- Fix operation amounts and add support for querying the balances of contracts.
+
 ## 0.3.2
 
 - Upgrade Rosetta spec to v1.4.12.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rosetta"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-rosetta"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/api/block.rs
+++ b/src/api/block.rs
@@ -74,10 +74,10 @@ fn block_transactions(block_summary: BlockSummary) -> Vec<Transaction> {
     // Inspired by the "coinbase" transaction in Bitcoin.
     let tokenomics_transaction = Transaction::new(
         TransactionIdentifier::new(TRANSACTION_HASH_TOKENOMICS.to_string()),
-        self::tokenomics_transaction_operations(&block_summary),
+        tokenomics_transaction_operations(&block_summary),
     );
     let mut res = vec![tokenomics_transaction];
-    res.extend(block_summary.transaction_summaries.iter().map(self::map_transaction));
+    res.extend(block_summary.transaction_summaries.iter().map(map_transaction));
     res
 }
 
@@ -105,7 +105,7 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                     _type:                OPERATION_TYPE_MINT_BAKING_REWARD.to_string(),
                     status:               Some(OPERATION_STATUS_OK.to_string()),
                     account:              Some(Box::new(AccountIdentifier::new(
-                        "baking_reward_account".to_string(),
+                        ACCOUNT_REWARD_BAKING.to_string(),
                     ))),
                     amount:               Some(Box::new(amount_from_uccd(
                         mint_baking_reward.microgtu as i128,
@@ -121,7 +121,7 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                     _type:                OPERATION_TYPE_MINT_FINALIZATION_REWARD.to_string(),
                     status:               Some(OPERATION_STATUS_OK.to_string()),
                     account:              Some(Box::new(AccountIdentifier::new(
-                        "finalization_reward_account".to_string(),
+                        ACCOUNT_REWARD_FINALIZATION.to_string(),
                     ))),
                     amount:               Some(Box::new(amount_from_uccd(
                         mint_finalization_reward.microgtu as i128,
@@ -154,8 +154,7 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                 foundation_account,
                 ..
             } => {
-                // Could add transaction fees going into GAS account and then extract block
-                // rewards, but it seems unnecessary?
+                // TODO Add gas account operations.
                 if baker_reward.microgtu != 0 {
                     res.push(Operation {
                         operation_identifier: Box::new(OperationIdentifier::new(next_index(
@@ -226,7 +225,7 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                     _type:                OPERATION_TYPE_BAKING_REWARD.to_string(),
                     status:               Some(OPERATION_STATUS_OK.to_string()),
                     account:              Some(Box::new(AccountIdentifier::new(
-                        ACCOUNT_BAKING_REWARD.to_string(),
+                        ACCOUNT_REWARD_BAKING.to_string(),
                     ))),
                     amount:               Some(Box::new(amount_from_uccd(-baking_reward_sum))),
                     coin_change:          None,
@@ -269,7 +268,7 @@ fn tokenomics_transaction_operations(block_summary: &BlockSummary) -> Vec<Operat
                     _type:                OPERATION_TYPE_FINALIZATION_REWARD.to_string(),
                     status:               Some(OPERATION_STATUS_OK.to_string()),
                     account:              Some(Box::new(AccountIdentifier::new(
-                        ACCOUNT_FINALIZATION_REWARD.to_string(),
+                        ACCOUNT_REWARD_FINALIZATION.to_string(),
                     ))),
                     amount:               Some(Box::new(amount_from_uccd(
                         -finalization_reward_sum,

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -42,6 +42,8 @@ pub enum ApiError {
     // Invalid input: Invalid value or identifier (type or format).
     #[error("invalid account address '{0}'")]
     InvalidAccountAddress(String),
+    #[error("invalid contract address '{0}'")]
+    InvalidContractAddress(String),
     #[error("invalid currency")]
     InvalidCurrency,
     #[error("invalid amount '{0}'")]

--- a/src/api/network.rs
+++ b/src/api/network.rs
@@ -86,6 +86,7 @@ impl NetworkApi {
                     handler_error::invalid_input_inconsistent_value_error(None, None),
                     handler_error::identifier_not_resolved_no_matches_error(None),
                     handler_error::identifier_not_resolved_multiple_matches_error(None),
+                    handler_error::internal_json_encoding_failed_error(None, None),
                     handler_error::proxy_client_rpc_error(None),
                     handler_error::proxy_client_query_error(None),
                     handler_error::proxy_transaction_rejected(),

--- a/src/handler_error.rs
+++ b/src/handler_error.rs
@@ -69,6 +69,15 @@ pub async fn handle_rejection(rej: Rejection) -> Result<impl Reply, Rejection> {
                     )),
                     StatusCode::BAD_REQUEST,
                 ),
+                ApiError::InvalidContractAddress(addr) => reply::with_status(
+                    reply::json(&invalid_input_invalid_value_or_identifier_error(
+                        Some("contract address".to_string()),
+                        None,
+                        Some(addr.clone()),
+                        Some("invalid format".to_string()),
+                    )),
+                    StatusCode::BAD_REQUEST,
+                ),
                 ApiError::InvalidCurrency => reply::with_status(
                     reply::json(&invalid_input_invalid_value_or_identifier_error(
                         Some("currency".to_string()),


### PR DESCRIPTION
## Purpose

Ensure that all operations emit correct amounts such that the `check:data` check of the Rosetta CLI tool passes.

## Changes

Many operation types had amount in their metadata instead of the operation itself. And for some odd reason, they had the fee as their amount which cancelled out the fee operation...

The following changes were included as part of this:

- Add support for querying contract balance.
- Cleanup: Only emit "fee" operation if it's amount is non-zero.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.