### PR TITLE
Use slot time of last finalized block for 'current_block_timestamp'

### DIFF
--- a/src/api/network.rs
+++ b/src/api/network.rs
@@ -112,10 +112,14 @@ impl NetworkApi {
                 index: consensus_status.last_finalized_block_height.height as i64,
                 hash:  consensus_status.last_finalized_block.to_string(),
             }),
-            current_block_timestamp:  consensus_status
-                .last_finalized_time
-                .map(|t| t.timestamp_millis())
-                .unwrap_or(-1),
+            current_block_timestamp:  self
+                .query_helper
+                .client
+                .clone()
+                .get_block_info(&consensus_status.last_finalized_block)
+                .await?
+                .block_slot_time
+                .timestamp_millis(),
             genesis_block_identifier: Box::new(BlockIdentifier {
                 index: 0,
                 hash:  consensus_status.genesis_block.to_string(),


### PR DESCRIPTION
## Purpose

Ensure that the value of `current_block_timestamp` is always well defined.

## Changes

The existing solution defaulted to -1 when the 'last_finalized_time' of 'consensus status' was None. This happens if the node wasn't online when the block was finalized and breaks the Rosetta CLI.

The slot time of the last finalized block, which is objectively agreed upon across all nodes, is now used instead.