### PR TITLE
Improve format of metadata for transfers with schedule

### DIFF
--- a/src/api/transaction.rs
+++ b/src/api/transaction.rs
@@ -113,9 +113,15 @@ struct TransferredToPublicMetadata {
 
 #[derive(SerdeSerialize)]
 struct TransferredWithScheduleMetadata {
-    amounts: Vec<(Timestamp, Amount)>, // TODO convert to map?
+    amounts: Vec<TimestampedAmount>,
     #[serde(skip_serializing_if = "Option::is_none")]
     memo:    Option<Memo>,
+}
+
+#[derive(SerdeSerialize)]
+struct TimestampedAmount {
+    timestamp: Timestamp,
+    amount: Amount,
 }
 
 #[derive(SerdeSerialize)]
@@ -432,7 +438,10 @@ fn operations_and_metadata_from_account_transaction_details(
                 to,
             ),
             Some(serde_json::to_value(&TransferredWithScheduleMetadata {
-                amounts: amount.clone(),
+                amounts: amount.iter().map(|(t, a)| TimestampedAmount{
+                    timestamp: *t,
+                    amount: *a,
+                }).collect(),
                 memo:    None,
             })),
         ),
@@ -447,7 +456,10 @@ fn operations_and_metadata_from_account_transaction_details(
                 to,
             ),
             Some(serde_json::to_value(&TransferredWithScheduleMetadata {
-                amounts: amount.clone(),
+                amounts: amount.iter().map(|(t, a)| TimestampedAmount{
+                    timestamp: *t,
+                    amount: *a,
+                }).collect(),
                 memo:    Some(memo.clone()),
             })),
         ),

--- a/src/api/transaction.rs
+++ b/src/api/transaction.rs
@@ -120,8 +120,8 @@ struct TransferredWithScheduleMetadata {
 
 #[derive(SerdeSerialize)]
 struct TimestampedAmount {
-    timestamp: Timestamp,
-    amount: Amount,
+    timestamp:   Timestamp,
+    amount_uccd: Amount,
 }
 
 #[derive(SerdeSerialize)]
@@ -438,10 +438,13 @@ fn operations_and_metadata_from_account_transaction_details(
                 to,
             ),
             Some(serde_json::to_value(&TransferredWithScheduleMetadata {
-                amounts: amount.iter().map(|(t, a)| TimestampedAmount{
-                    timestamp: *t,
-                    amount: *a,
-                }).collect(),
+                amounts: amount
+                    .iter()
+                    .map(|(t, a)| TimestampedAmount {
+                        timestamp:   *t,
+                        amount_uccd: *a,
+                    })
+                    .collect(),
                 memo:    None,
             })),
         ),
@@ -456,10 +459,13 @@ fn operations_and_metadata_from_account_transaction_details(
                 to,
             ),
             Some(serde_json::to_value(&TransferredWithScheduleMetadata {
-                amounts: amount.iter().map(|(t, a)| TimestampedAmount{
-                    timestamp: *t,
-                    amount: *a,
-                }).collect(),
+                amounts: amount
+                    .iter()
+                    .map(|(t, a)| TimestampedAmount {
+                        timestamp:   *t,
+                        amount_uccd: *a,
+                    })
+                    .collect(),
                 memo:    Some(memo.clone()),
             })),
         ),


### PR DESCRIPTION
## Purpose

Make the schedule metadata of transfers with schedule easier to understand.

## Changes

Based on [this](https://github.com/Concordium/concordium-rosetta/pull/33#discussion_r892895884) comment, change

```
"amounts": [
  [
    1665403200000,
    "100000000"
  ],
  ...
]
```

into

```
"amounts": [
  {
    timestamp: 1665403200000,
    amount_uccd: "100000000"
  },
  ...
]
```

The name (and unit of) `timestamp` is chosen for consistency with the `current_block_timestamp` field of  [`/network/status`](https://www.rosetta-api.org/docs/models/NetworkStatusResponse.html). The name `amount_uccd` is consistent with other similar uses.