### PR TITLE
Emit baker ID in metadata of BlockResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.1
+
+- Add field `baker_id` in metadata of `BlockResponse`.
+
 ## 0.6.0
 
 - Bump Node SDK.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rosetta"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-rosetta"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Purpose

Enable clients to determine the baker of a given block using the `/block` endpoint.

I vaguely recall that this was "requested" (or at least enquired) some time ago. In any case, I think it's a reasonable add.

## Changes

Add field `baker_id` in metadata of `BlockResponse`. Resolves #47.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.