### PR TITLE
CI: Update actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch: # allow manual trigger
 
 env:
-  RUST_FMT: nightly-2022-06-09-x86_64-unknown-linux-gnu
+  RUST_TOOLCHAIN_FMT: nightly-2022-06-09-x86_64-unknown-linux-gnu
   RUST_TOOLCHAIN: 1.62
 
 jobs:
@@ -23,14 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.RUST_FMT }}
-          override: true
-          components: rustfmt
+        run: |
+          rustup override set "${{ env.RUST_TOOLCHAIN_FMT }}"
+          rustup component add rustfmt
       - name: Format
         run: |
           cargo fmt -- --color=always --check
@@ -57,17 +54,13 @@ jobs:
           unzip protoc-3.15.3-linux-x86_64.zip
           sudo mv ./bin/protoc /usr/bin/protoc
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
-          target: ${{ env.TARGET }}
-          components: rustfmt, clippy
+        run: |
+          rustup override set "${{ env.RUST_TOOLCHAIN }}"
+          rustup component add clippy
       - name: Clippy
         run: |
           cargo clippy --color=always --tests --benches -- -Dclippy::all


### PR DESCRIPTION
## Purpose

Address GitHub Actions [deprecation warnings](https://github.com/Concordium/concordium-rosetta/actions/runs/4261439548).

The checkout action is updated to deprecation warnings in the workflow output. The Rust toolchain action seems abandoned and is also redundant because [rustup is installed](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md) in the VMs already.
## Changes

Bump/replace actions.