### PR TITLE
Compose: Bump default build image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@
 #
 # Example:
 #
-#   CONCORDIUM_ROSETTA_IMAGE=concordium/rosetta:0.6.0-0 \
+#   CONCORDIUM_ROSETTA_IMAGE=concordium/rosetta:0.7.0-0 \
 #   CONCORDIUM_ROSETTA_GRPC_HOST=node.mainnet.concordium.example.com \
 #   CONCORDIUM_ROSETTA_NETWORK=mainnet \
 #   docker-compose up -d
@@ -30,7 +30,7 @@ services:
     build:
       context: .
       args:
-        build_image: ${BUILD_IMAGE-rust:1.56-slim-buster}
+        build_image: ${BUILD_IMAGE-rust:1.62-slim-buster}
         base_image: ${BASE_IMAGE-debian:buster-slim}
     image: ${CONCORDIUM_ROSETTA_IMAGE-concordium/rosetta:test}
     environment:


### PR DESCRIPTION
## Purpose

Ensure that default build args in `docker-compose.yaml` work.

## Changes

Upgraded default build image from rust version 1.56 to 1.62 as this is the minimum supported version as of commit 4c7d91dabae31a8c58a26ff8d667dd7eecc0a8e8.