### PR TITLE
Docker Compose: Add optional deployment of 'rosetta-cli' running 'check:data'

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,13 +566,14 @@ Also, the block containing the transaction has to be finalized for the transacti
 
 ### Rosetta CLI tool
 
-The Rosetta team maintains a CLI that includes commands for verifying that the implementation produces valid results.
+The Rosetta team maintains a [CLI tool](https://github.com/coinbase/mesh-cli) that includes commands
+for verifying that the implementation produces valid results.
 This includes consistency checks of the balance of all accounts,
 i.e. that all changes in balances are accounted for in transactions.
 
 The test will fail if run with the official Rosetta CLI tool because it doesn't understand how Concordium does account aliases.
-We therefore forked the tool to make it accept that a transaction affecting the balance of an
-account affects all aliases of that account as well.
+We therefore [forked](https://github.com/Concordium/rosetta-cli) the tool to make it accept
+that a transaction affecting the balance of an account affects all aliases of that account as well.
 
 To run the test you need a running instance of both the
 [concordium-node](https://github.com/Concordium/concordium-node) and

--- a/README.md
+++ b/README.md
@@ -564,17 +564,25 @@ Also, the block containing the transaction has to be finalized for the transacti
 
 ## Testing
 
-### Running Rosetta CLI for testing
+### Rosetta CLI tool
 
-We forked the Rosetta CLI tool to make it understand account aliases, i.e. that a 
-transaction affecting the balance of an account affects all aliases of that 
-account as well.
+The Rosetta team maintains a CLI that includes commands for verifying that the implementation produces valid results.
+This includes consistency checks of the balance of all accounts,
+i.e. that all changes in balances are accounted for in transactions.
 
-The test will fail if run with the official Rosetta CLI tool.
+The test will fail if run with the official Rosetta CLI tool because it doesn't understand how Concordium does account aliases.
+We therefore forked the tool to make it accept that a transaction affecting the balance of an
+account affects all aliases of that account as well.
 
-To run our forked rosetta-cli tool you must have a running instance of both the
+To run the test you need a running instance of both the
 [concordium-node](https://github.com/Concordium/concordium-node) and
-the concordium rosetta API implementation:
+the Conocordium Rosetta.
+
+The easiest way to run Rosetta and the tool is by using the [provided](./docker-compose.yaml) Docker Compose deployment
+with the profile `check-data` enabled.
+See the following sections for alternative methods.
+
+#### Build and run (direct)
 
 ```bash
 concordium-rosetta --network testnet
@@ -606,7 +614,7 @@ We need to make the following changes to this configuration:
   when Rosetta was started (i.e. `testnet` in the command above).
 - The blockchain field should be set to `"concordium"`
 - Setting `"max_retries": 32768` makes sure the test doesn't stop 
-  on a tempoary network outage.
+  on a temporary network outage.
 
 Now the test tool can be run:
 
@@ -619,10 +627,10 @@ Note that this only tests the data returned by the Rosetta
 API implementation is valid. It does not test interaction
 on chain, such as transactions. We test that with a different
 [tool](https://github.com/Concordium/concordium-rosetta#transfer-client).
-There is more info on the [Rosetta-API
-website](https://www.rosetta-api.org/docs/rosetta_cli.html#checkdata-1).
+There is more info on the
+[Rosetta-API website](https://www.rosetta-api.org/docs/rosetta_cli.html#checkdata-1).
 
-### Rosetta CLI (Docker)
+#### Build and run (Docker)
 
 You can also build using the provided docker file in [`tools/rosetta-cli-docker`](./tools/rosetta-cli-docker)
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,7 @@
 # - The value of `CONCORDIUM_ROSETTA_PORT` only determines the port exposed to the host.
 #   The internal port is hard-coded to 8080.
 #   The default value of the exposed port is still 8080.
+#   Don't change this when running with profile 'check:data' as the Rosetta CLI expects to use this port on the host.
 #
 # The image containing the application is set using `CONCORDIUM_ROSETTA_IMAGE`.
 # If this value isn't provided it will default to an image that doesn't exist in the public repo,
@@ -18,7 +19,7 @@
 #
 # Example:
 #
-#   CONCORDIUM_ROSETTA_IMAGE=concordium/rosetta:0.7.0-0 \
+#   ROSETTA_IMAGE=concordium/rosetta:0.7.0-0 \
 #   CONCORDIUM_ROSETTA_GRPC_HOST=node.mainnet.concordium.example.com \
 #   CONCORDIUM_ROSETTA_NETWORK=mainnet \
 #   docker-compose up -d
@@ -30,9 +31,9 @@ services:
     build:
       context: .
       args:
-        build_image: ${BUILD_IMAGE-rust:1.62-slim-buster}
-        base_image: ${BASE_IMAGE-debian:buster-slim}
-    image: ${CONCORDIUM_ROSETTA_IMAGE-concordium/rosetta:test}
+        build_image: ${ROSETTA_BUILD_IMAGE-rust:1.62-slim-buster}
+        base_image: ${ROSETTA_BASE_IMAGE-debian:buster-slim}
+    image: ${ROSETTA_IMAGE-rosetta:test}
     environment:
     - CONCORDIUM_ROSETTA_GRPC_HOST=${CONCORDIUM_ROSETTA_GRPC_HOST-172.17.0.1}
     - CONCORDIUM_ROSETTA_GRPC_PORT
@@ -42,3 +43,17 @@ services:
     ports: # alternative: use "network_mode: host"
     - "${CONCORDIUM_ROSETTA_PORT-8080}:8080"
     stop_signal: SIGKILL
+  rosetta-cli-check-data:
+    profiles: [check:data]
+    container_name: rosetta-cli-check-data
+    build:
+      context: ./tools/rosetta-cli-docker
+      args:
+        build_image: ${ROSETTA_CLI_BUILD_IMAGE-golang:1.16-buster} # the project lists "go 1.16" in 'go.mod'
+        base_image: ${ROSETTA_CLI_BASE_IMAGE-debian:buster-slim}
+    image: ${ROSETTA_CLI_IMAGE-rosetta-cli:test}
+    # TODO Consider mounting in config file that uses rosetta directly on the internal network.
+    depends_on:
+    - rosetta
+    command:
+    - check:data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,11 +9,11 @@
 # - The value of `CONCORDIUM_ROSETTA_PORT` only determines the port exposed to the host.
 #   The internal port is hard-coded to 8080.
 #   The default value of the exposed port is still 8080.
-#   Don't change this when running with profile 'check:data' as the Rosetta CLI expects to use this port on the host.
+#   Don't change this when running with profile 'check-data' as the Rosetta CLI expects to use this port on the host.
 #
 # The image containing the application is set using `ROSETTA_IMAGE`.
-# If this value isn't provided, it will default to an image that doesn't exist in the public repo,
-# which will cause Compose to build the image from source.
+# If this value isn't provided, it will default to an image that doesn't exist publicly ("concordium-rosetta:test).
+# This will cause Compose to build the image from source.
 # Note that the image is cached locally so will be used without rebuild in subsequent runs, even if the source code has changed.
 # Delete the image or change `ROSETTA_IMAGE` to rebuild.
 #
@@ -21,23 +21,23 @@
 #
 # Example:
 #
-#   ROSETTA_IMAGE=concordium/rosetta:0.7.0-0 \
+#   ROSETTA_IMAGE=concordium/rosetta:1.0.0-0 \
 #   CONCORDIUM_ROSETTA_GRPC_HOST=node.mainnet.concordium.example.com \
 #   CONCORDIUM_ROSETTA_NETWORK=mainnet \
-#   docker-compose up -d
+#   docker compose up -d
 #
 # For testing the implementation, an extra service `rosetta-cli-check-data` may be included.
 # This is a custom fork of the official Rosetta CLI that understands Concordium account aliases (see './tools/rosetta-cli-docker').
-# Run the deployment with Compose profile `check:data` to enable this service.
+# Run the deployment with Compose profile `check-data` to enable this service.
 # The baked in configuration of the tool expects the following:
 # - Rosetta is exposed on port 8080 on the host network.
 # - The network is set to "rosetta".
 #
 # Example:
-#   ROSETTA_IMAGE=concordium/rosetta:0.7.0-0 \
+#   ROSETTA_IMAGE=concordium/rosetta:1.0.0-0 \
 #   CONCORDIUM_ROSETTA_GRPC_HOST=node.mainnet.concordium.example.com \
 #   CONCORDIUM_ROSETTA_NETWORK=rosetta \
-#   docker-compose --profile=check:data up -d
+#   docker compose --profile=check-data up -d
 
 version: '3'
 services:
@@ -46,20 +46,19 @@ services:
     build:
       context: .
       args:
-        build_image: ${ROSETTA_BUILD_IMAGE-rust:1.62-slim-buster}
+        build_image: ${ROSETTA_BUILD_IMAGE-rust:1.66-slim-buster}
         base_image: ${ROSETTA_BASE_IMAGE-debian:buster-slim}
-    image: ${ROSETTA_IMAGE-concordium/rosetta:test}
+    image: ${ROSETTA_IMAGE-concordium-rosetta:test}
     environment:
     - CONCORDIUM_ROSETTA_GRPC_HOST=${CONCORDIUM_ROSETTA_GRPC_HOST-172.17.0.1}
     - CONCORDIUM_ROSETTA_GRPC_PORT
-    - CONCORDIUM_ROSETTA_GRPC_TOKEN
     - CONCORDIUM_ROSETTA_NETWORK
     - CONCORDIUM_ROSETTA_PORT=8080
-    ports: # alternative: use "network_mode: host"
+    ports:
     - "${CONCORDIUM_ROSETTA_PORT-8080}:8080"
     stop_signal: SIGKILL
   rosetta-cli-check-data:
-    profiles: [check:data]
+    profiles: [ check-data ]
     container_name: rosetta-cli-check-data
     build:
       context: ./tools/rosetta-cli-docker
@@ -72,4 +71,4 @@ services:
     depends_on:
     - rosetta
     command:
-    - check:data
+    - "check:data"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-# Deployment for running a single Concordium Rosetta instance.
+# Deployment for running a single Concordium Rosetta instance, optionally with an instance of rosetta-cli.
 # The deployment supports all the usual env vars of the service.
 #
 # Most values are passed directly to the service with no default values.
@@ -11,9 +11,11 @@
 #   The default value of the exposed port is still 8080.
 #   Don't change this when running with profile 'check:data' as the Rosetta CLI expects to use this port on the host.
 #
-# The image containing the application is set using `CONCORDIUM_ROSETTA_IMAGE`.
-# If this value isn't provided it will default to an image that doesn't exist in the public repo,
+# The image containing the application is set using `ROSETTA_IMAGE`.
+# If this value isn't provided, it will default to an image that doesn't exist in the public repo,
 # which will cause Compose to build the image from source.
+# Note that the image is cached locally so will be used without rebuild in subsequent runs, even if the source code has changed.
+# Delete the image or change `ROSETTA_IMAGE` to rebuild.
 #
 # Finally, `CONCORDIUM_ROSETTA_NETWORK` has no default value so must be set explicitly.
 #
@@ -23,6 +25,19 @@
 #   CONCORDIUM_ROSETTA_GRPC_HOST=node.mainnet.concordium.example.com \
 #   CONCORDIUM_ROSETTA_NETWORK=mainnet \
 #   docker-compose up -d
+#
+# For testing the implementation, an extra service `rosetta-cli-check-data` may be included.
+# This is a custom fork of the official Rosetta CLI that understands Concordium account aliases (see './tools/rosetta-cli-docker').
+# Run the deployment with Compose profile `check:data` to enable this service.
+# The baked in configuration of the tool expects the following:
+# - Rosetta is exposed on port 8080 on the host network.
+# - The network is set to "rosetta".
+#
+# Example:
+#   ROSETTA_IMAGE=concordium/rosetta:0.7.0-0 \
+#   CONCORDIUM_ROSETTA_GRPC_HOST=node.mainnet.concordium.example.com \
+#   CONCORDIUM_ROSETTA_NETWORK=rosetta \
+#   docker-compose --profile=check:data up -d
 
 version: '3'
 services:
@@ -33,7 +48,7 @@ services:
       args:
         build_image: ${ROSETTA_BUILD_IMAGE-rust:1.62-slim-buster}
         base_image: ${ROSETTA_BASE_IMAGE-debian:buster-slim}
-    image: ${ROSETTA_IMAGE-rosetta:test}
+    image: ${ROSETTA_IMAGE-concordium/rosetta:test}
     environment:
     - CONCORDIUM_ROSETTA_GRPC_HOST=${CONCORDIUM_ROSETTA_GRPC_HOST-172.17.0.1}
     - CONCORDIUM_ROSETTA_GRPC_PORT
@@ -51,8 +66,9 @@ services:
       args:
         build_image: ${ROSETTA_CLI_BUILD_IMAGE-golang:1.16-buster} # the project lists "go 1.16" in 'go.mod'
         base_image: ${ROSETTA_CLI_BASE_IMAGE-debian:buster-slim}
-    image: ${ROSETTA_CLI_IMAGE-rosetta-cli:test}
+    image: ${ROSETTA_CLI_IMAGE-concordium/rosetta-cli:test}
     # TODO Consider mounting in config file that uses rosetta directly on the internal network.
+    #      Or maybe generating the file on runtime with some parameterized settings would be better...
     depends_on:
     - rosetta
     command:

--- a/tools/rosetta-cli-docker/Dockerfile
+++ b/tools/rosetta-cli-docker/Dockerfile
@@ -4,7 +4,7 @@ ARG base_image
 # Build stage.
 FROM ${build_image} AS build
 ARG repo=https://github.com/Concordium/rosetta-cli.git
-ARG branch
+ARG branch=concordium
 # Make anything contained in the context root folder available to the build.
 # This may be used to build from a local subrepo 'rosetta-cli':
 #   --build-arg=repo=file:///tmp/rosetta-cli

--- a/tools/transfer-client/README.md
+++ b/tools/transfer-client/README.md
@@ -10,7 +10,7 @@ It's not meant to be used to do real transfers as there are other tools that are
 
 The tool is specifically built to integrate with the Concordium Rosetta implementation;
 implementations for other blockchains are not supported.
-The main Concordium-specific parts are key handling and the [signature index quirk](/README.md#construction_api)
+The main Concordium-specific parts are key handling and the [signature index quirk](/README.md#construction-api)
 in the `combine` endpoint.
 
 ## Usage
@@ -35,7 +35,7 @@ The expected JSON format of the keys file is
       "keys": {
         <key-index>: {
           "signKey": ...,
-          "verifyKey": ...,
+          "verifyKey": ...
         },
         ...
       },


### PR DESCRIPTION
## Purpose

Simplify the process of running the `check:data` check against the Rosetta implementation.

## Changes

Added a deployment `rosetta-cli-check-data` under the profile `check-data`.

Tested against local node (deployed using [`concordium-docker`](https://github.com/bisgardo/concordium-docker)) with command

```shell
ROSETTA_IMAGE=concordium/rosetta:1.1.0-1 CONCORDIUM_ROSETTA_GRPC_PORT=11000 CONCORDIUM_ROSETTA_NETWORK=rosetta docker compose --profile=check-data up
```

and also excluding the profile.