### PR TITLE
Ensuring concordium rosetta can work with the newer sdk version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch: # allow manual trigger
 
 env:
-  RUST_TOOLCHAIN: "1.73"
+  RUST_TOOLCHAIN: "1.85"
 
 jobs:
   fmt:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
       - "*.*.*"
 
 env:
-  RUST_VERSION: '1.73'
+  RUST_VERSION: '1.85'
   IAM_ROLE: "arn:aws:iam::192549843005:role/github_concordium-rosetta" 
   BASE_IMAGE: "debian:bullseye-slim"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ##
 
 - Bumping up Rust SDK version to newer one which support protocol version 9.
+- Setting rust version to be 1.85
 
 ## 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased changes
 
+##
+
+- Bumping up Rust SDK version to newer one which support protocol version 9. No PLT operations
+are supported yet, they are marked with todo macro
+
 ## 1.3.0
 
 - Support protocol version 8:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ##
 
-- Bumping up Rust SDK version to newer one which support protocol version 9. No PLT operations
-are supported yet, they are marked with todo macro
+- Bumping up Rust SDK version to newer one which support protocol version 9.
 
 ## 1.3.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,18 +299,17 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "itoa",
  "matchit",
  "memchr",
@@ -313,25 +318,28 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
+ "sync_wrapper",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "mime",
+ "pin-project-lite",
  "rustversion",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -434,7 +442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8b668d39970baad5356d7c83a86fee3a539e6f93bf6764c97368243e17a0487"
 dependencies = [
  "once_cell",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -536,6 +544,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,7 +625,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -627,7 +651,7 @@ dependencies = [
  "rosetta",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic 0.5.2",
  "warp",
@@ -635,10 +659,11 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "6.0.0"
+version = "7.0.0-alpha.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
+ "assert_matches",
  "chrono",
  "concordium-smart-contract-engine",
  "concordium_base",
@@ -646,27 +671,27 @@ dependencies = [
  "ed25519-dalek",
  "futures",
  "hex",
- "http 0.2.12",
+ "http 1.2.0",
  "num",
  "num-bigint",
  "num-traits",
- "prost 0.12.6",
+ "prost 0.13.5",
  "rand",
  "rust_decimal",
  "semver",
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
- "tonic 0.10.2",
+ "tonic 0.12.3",
  "tracing",
 ]
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -683,13 +708,13 @@ dependencies = [
  "sha2",
  "sha3",
  "slab",
- "thiserror",
+ "thiserror 1.0.69",
  "tinyvec",
 ]
 
 [[package]]
 name = "concordium-wasm"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -700,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -709,11 +734,13 @@ dependencies = [
  "ark-ff",
  "ark-serialize",
  "ark-std",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bs58",
  "byteorder",
  "cbc",
  "chrono",
+ "ciborium-io",
+ "ciborium-ll",
  "concordium-contracts-common",
  "concordium_base_derive",
  "curve25519-dalek",
@@ -723,7 +750,7 @@ dependencies = [
  "ff",
  "hex",
  "hmac",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "leb128",
  "libc",
  "nom",
@@ -740,14 +767,17 @@ dependencies = [
  "sha2",
  "sha3",
  "subtle",
- "thiserror",
+ "thiserror 2.0.16",
  "zeroize",
 ]
 
 [[package]]
 name = "concordium_base_derive"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
+ "convert_case 0.8.0",
+ "darling",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -764,6 +794,15 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -816,6 +855,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -876,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -890,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -942,7 +987,7 @@ version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1304,6 +1349,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1563,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1542,6 +1598,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.6.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1799,6 +1868,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2256,11 +2334,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
- "toml_edit 0.22.22",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -2308,12 +2386,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive 0.12.6",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
@@ -2331,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -2497,7 +2575,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -2567,9 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.36.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
+checksum = "c8975fc98059f365204d635119cf9c5a60ae67b841ed49b5422a9a7e56cdfac0"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -2944,12 +3022,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -3030,7 +3102,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+dependencies = [
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -3038,6 +3119,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3209,9 +3301,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_edit"
@@ -3226,13 +3318,13 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.7.1",
  "toml_datetime",
- "winnow 0.6.25",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -3251,7 +3343,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
  "prost 0.8.0",
@@ -3268,23 +3360,26 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.10.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-timeout",
+ "h2 0.4.7",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-timeout 0.5.2",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.12.6",
+ "prost 0.13.5",
+ "socket2",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -3322,7 +3417,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -3402,7 +3497,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "utf-8",
 ]
@@ -3424,6 +3519,12 @@ name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "universal-hash"
@@ -3785,9 +3886,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.25"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "concordium-rosetta"
 version = "1.3.0"
 edition = "2018"
-rust-version = "1.73"
+rust-version = "1.85"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,6 @@ rust-version = "1.73"
 
 [dependencies.concordium-rust-sdk]
 path = "./concordium-rust-sdk"
-## version = "*"
-version = "7.0.0-alpha.4"
 
 [dependencies.rosetta]
 path = "./rosetta"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ rust-version = "1.73"
 [dependencies.concordium-rust-sdk]
 path = "./concordium-rust-sdk"
 ## version = "*"
+version = "7.0.0-alpha.4"
 
 [dependencies.rosetta]
 path = "./rosetta"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.73"
 
 [dependencies.concordium-rust-sdk]
 path = "./concordium-rust-sdk"
-version = "*"
+## version = "*"
 
 [dependencies.rosetta]
 path = "./rosetta"

--- a/src/api/transaction.rs
+++ b/src/api/transaction.rs
@@ -301,7 +301,9 @@ pub fn map_transaction(info: BlockItemSummary) -> Transaction {
             operations_and_metadata_from_chain_update_details(details),
             None,
         ),
-        BlockItemSummaryDetails::TokenCreationDetails(details) => todo!("Token creation not yet supported"),
+        BlockItemSummaryDetails::TokenCreationDetails(details) => {
+            todo!("Token creation not yet supported")
+        }
     };
     Transaction {
         transaction_identifier: Box::new(TransactionIdentifier {
@@ -836,7 +838,7 @@ fn operations_and_metadata_from_account_transaction_details(
                 .collect(),
             None,
         ),
-        AccountTransactionEffects::TokenUpdate{ .. } => todo!("Token update not yet supported"),
+        AccountTransactionEffects::TokenUpdate { .. } => todo!("Token update not yet supported"),
     }
 }
 

--- a/src/api/transaction.rs
+++ b/src/api/transaction.rs
@@ -839,7 +839,7 @@ fn operations_and_metadata_from_account_transaction_details(
                 .collect(),
             None,
         ),
-        AccountTransactionEffects::TokenUpdate { .. } => { 
+        AccountTransactionEffects::TokenUpdate { .. } => {
             log::warn!("Token update not yet supported");
             (vec![], None)
         }

--- a/src/api/transaction.rs
+++ b/src/api/transaction.rs
@@ -302,7 +302,8 @@ pub fn map_transaction(info: BlockItemSummary) -> Transaction {
             None,
         ),
         BlockItemSummaryDetails::TokenCreationDetails(details) => {
-            todo!("Token creation not yet supported")
+            log::warn!("Token creation not yet supported");
+            (vec![], None)
         }
     };
     Transaction {
@@ -838,7 +839,10 @@ fn operations_and_metadata_from_account_transaction_details(
                 .collect(),
             None,
         ),
-        AccountTransactionEffects::TokenUpdate { .. } => todo!("Token update not yet supported"),
+        AccountTransactionEffects::TokenUpdate { .. } => { 
+            log::warn!("Token update not yet supported");
+            (vec![], None)
+        }
     }
 }
 

--- a/src/api/transaction.rs
+++ b/src/api/transaction.rs
@@ -261,6 +261,7 @@ pub const OPERATION_TYPE_CONFIGURE_BAKER: &str = "configure_baker";
 pub const OPERATION_TYPE_CONFIGURE_DELEGATION: &str = "configure_delegation";
 pub const OPERATION_TYPE_VALIDATOR_PRIMED_FOR_SUSPENSION: &str = "validator_primed_for_suspension";
 pub const OPERATION_TYPE_VALIDATOR_SUSPENDED: &str = "validator_suspended";
+pub const OPERATION_TYPE_TOKEN_UPDATE: &str = "token_update";
 
 pub const TRANSACTION_HASH_TOKENOMICS: &str = "tokenomics";
 
@@ -300,6 +301,7 @@ pub fn map_transaction(info: BlockItemSummary) -> Transaction {
             operations_and_metadata_from_chain_update_details(details),
             None,
         ),
+        BlockItemSummaryDetails::TokenCreationDetails(details) => todo!("Token creation not yet supported"),
     };
     Transaction {
         transaction_identifier: Box::new(TransactionIdentifier {
@@ -834,6 +836,7 @@ fn operations_and_metadata_from_account_transaction_details(
                 .collect(),
             None,
         ),
+        AccountTransactionEffects::TokenUpdate{ .. } => todo!("Token update not yet supported"),
     }
 }
 
@@ -1097,6 +1100,7 @@ pub fn transaction_type_to_operation_type(type_: Option<TransactionType>) -> Str
             TransactionType::UpdateCredentials => OPERATION_TYPE_UPDATE_CREDENTIALS,
             TransactionType::ConfigureBaker => OPERATION_TYPE_CONFIGURE_BAKER,
             TransactionType::ConfigureDelegation => OPERATION_TYPE_CONFIGURE_DELEGATION,
+            TransactionType::TokenUpdate => OPERATION_TYPE_TOKEN_UPDATE,
         },
     };
     res.to_string()

--- a/tools/transfer-client-direct/Cargo.toml
+++ b/tools/transfer-client-direct/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies.concordium-rust-sdk]
 path = "../../concordium-rust-sdk"
-version = "*"
+
 
 [dependencies]
 anyhow = "1"

--- a/tools/transfer-client/Cargo.toml
+++ b/tools/transfer-client/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2018"
 
 [dependencies.concordium-rust-sdk]
 path = "../../concordium-rust-sdk"
-version = "*"
 
 [dependencies.rosetta]
 path = "../../rosetta"


### PR DESCRIPTION
## Purpose

Currently, concordium-rosetta won't work with newer version of rust sdk. This PR is basically bumping up the sdk version and ensuring there are no compilation errors. Anything with the PLT operations are marked with todo macro.

## Changes

Making sure the concordium-rosetta build fine and can be run without any issue pointing to the newer rust sdk version

## Checklist

- [ x ] My code follows the style of this project.
- [ x ] The code compiles without warnings.
- [ x ] I have performed a self-review of the changes.
- [ x ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ x ] (If necessary) I have updated the CHANGELOG.

